### PR TITLE
Add query to calculate total sales by day

### DIFF
--- a/consultas-utiles.sql
+++ b/consultas-utiles.sql
@@ -44,4 +44,15 @@ GROUP BY
 	M.NOMBRE,
 	M.APELLIDO;
 
+-- obtener el total de ventas por día
+SELECT
+	TRUNC(FECHA_EMISION) AS DIA,
+	SUM(TOTAL)           AS TOTAL_VENTAS
+FROM
+	COMPROBANTE
+GROUP BY
+	TRUNC(FECHA_EMISION)
+ORDER BY
+	DIA;
+
 -- mas proximamente


### PR DESCRIPTION
This pull request includes a small change to the `consultas-utiles.sql` file. The change adds a new query to obtain the total sales per day.

* [`consultas-utiles.sql`](diffhunk://#diff-1b1583c0944877851b138b704900b1ef953f7d3bf19e8d1870d2ef62cfab857eR47-R57): Added a query to calculate and order the total sales by day using `TRUNC(FECHA_EMISION)` and `SUM(TOTAL)` in the `GROUP BY` clause.